### PR TITLE
Split WeatherForecastService into Historical and Streaming RPCs

### DIFF
--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -23,8 +23,9 @@ import "google/protobuf/timestamp.proto";
 //     Weather forecasts are inherently uncertain and actual conditions may
 //     vary. Use the data responsibly.
 service WeatherForecastService {
-  // Streams the weather forecast features for a geo location.
-  rpc SubscribeWeatherForecast(ForecastRequest)
+  // Streams live weather forecast features for a geo location as they become
+  // available. Initially, the most recent forecast will be streamed.
+  rpc StreamLiveWeatherForecast (ForecastRequest)
     returns (stream ForecastResponse);
 }
 
@@ -74,14 +75,12 @@ message ForecastRequest {
   // will be streamed.
   repeated ForecastFeature features = 2;
 
+  // Optional for StreamLiveWeatherForecast, ignored if provided.
   // The start of the period for which the forecast is being requested.
-  // If not provided, the service will default to the most recent forecast
-  // available.
   google.protobuf.Timestamp start_ts = 3;
 
+  // Optional for StreamLiveWeatherForecast, ignored if provided.
   // The end of the period for which the forecast is being requested.
-  // If not provided, the forecast will be streamed indefinitely as new data 
-  // becomes available.
   google.protobuf.Timestamp end_ts = 4;
 
   // Specifies the maximum number of forecasts to be returned in a single

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -88,6 +88,7 @@ message ForecastRequest {
   // The end of the period for which the forecast is being requested.
   google.protobuf.Timestamp end_ts = 4;
 
+  // Optional for StreamLiveWeatherForecast, ignored if provided.
   // Specifies the maximum number of forecasts to be returned in a single
   // response.
   int32 page_size = 5;

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -76,7 +76,7 @@ message ForecastRequest {
   // The location for which the forecast is being requested.
   frequenz.api.common.location.Location location = 1;
 
-  // List of required features.  If none are specified, all available features
+  // List of required features. If none are specified, all available features
   // will be streamed.
   repeated ForecastFeature features = 2;
 

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -23,6 +23,11 @@ import "google/protobuf/timestamp.proto";
 //     Weather forecasts are inherently uncertain and actual conditions may
 //     vary. Use the data responsibly.
 service WeatherForecastService {
+  // Returns historical weather forecast features for a geo location for a
+  // specified time range.
+  rpc GetHistoricalWeatherForecast (ForecastRequest)
+    returns (ForecastResponse);
+
   // Streams live weather forecast features for a geo location as they become
   // available. Initially, the most recent forecast will be streamed.
   rpc StreamLiveWeatherForecast (ForecastRequest)


### PR DESCRIPTION
- Introduced GetHistoricalWeatherForecast for historical data.

- Introduced StreamLiveWeatherForecast for live streaming.

- Deprecated SubscribeWeatherForecast method.

- Adjusted ForecastRequest fields to cater to the new services.

- Updated comments to reflect the service split and usage.