### PR TITLE
Split request message and update time description

### DIFF
--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -25,7 +25,7 @@ import "google/protobuf/timestamp.proto";
 service WeatherForecastService {
   // Returns historical weather forecast features for a geo location for a
   // specified time range.
-  rpc GetHistoricalWeatherForecast (ForecastRequest)
+  rpc GetHistoricalWeatherForecast (GetHistoricalWeatherForecastRequest)
     returns (ForecastResponse);
 
   // Streams live weather forecast features for a geo location as they become
@@ -69,26 +69,25 @@ enum ForecastFeature {
   FORECAST_FEATURE_SURFACE_NET_SOLAR_RADIATION = 4;
 }
 
-// The ForecastRequest message is used to specify the parameters for the
-// SubscribeWeatherForecast method. It allows users to request weather forecasts
-// for a specific location and time period, with specified features. 
-message ForecastRequest {
+// The GetHistoricalWeatherForecastRequest message defines parameters for
+// retrieving historical weather forecasts, targeting a specific location
+// and time period, with designated features.
+message GetHistoricalWeatherForecastRequest {
   // The location for which the forecast is being requested.
   frequenz.api.common.location.Location location = 1;
 
   // List of required features. If none are specified, all available features
-  // will be streamed.
+  // will be returned.
   repeated ForecastFeature features = 2;
 
-  // Optional for StreamLiveWeatherForecast, ignored if provided.
-  // The start of the period for which the forecast is being requested.
+  // The start of the period for which the historical forecast is being
+  // requested.
   google.protobuf.Timestamp start_ts = 3;
 
-  // Optional for StreamLiveWeatherForecast, ignored if provided.
-  // The end of the period for which the forecast is being requested.
+  // The end of the period for which the historical forecast is being
+  // requested.
   google.protobuf.Timestamp end_ts = 4;
 
-  // Optional for StreamLiveWeatherForecast, ignored if provided.
   // Specifies the maximum number of forecasts to be returned in a single
   // response.
   int32 page_size = 5;

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -80,12 +80,12 @@ message GetHistoricalWeatherForecastRequest {
   // will be returned.
   repeated ForecastFeature features = 2;
 
-  // The start of the period for which the historical forecast is being
-  // requested.
+  // The UTC timestamp indicating the start of the requested historical forecast
+  // period.
   google.protobuf.Timestamp start_ts = 3;
 
-  // The end of the period for which the historical forecast is being
-  // requested.
+  // The UTC timestamp indicating the end of the requested historical forecast
+  // period.
   google.protobuf.Timestamp end_ts = 4;
 
   // Specifies the maximum number of forecasts to be returned in a single
@@ -107,7 +107,7 @@ message StreamLiveWeatherForecastRequest {
 
 // The ForecastResponse message encapsulates the weather forecast data returned
 // by the SubscribeWeatherForecast method. It provides a structured format for
-// representing forecast data for a specific location, including timestamps
+// representing forecast data for a specific location, including UTC timestamps
 // for validity and creation.
 message ForecastResponse {
 
@@ -124,7 +124,7 @@ message ForecastResponse {
       float value = 2;
     }
 
-    // The timestamp for which the features in this entry are valid for.
+    // The UTC timestamp for which the features in this entry are valid for.
     google.protobuf.Timestamp valid_at_ts = 1;
 
     // All requested weather features.
@@ -137,6 +137,6 @@ message ForecastResponse {
   // The location for which the weather data is returned.
   frequenz.api.common.location.Location location = 2;
 
-  // The timestamp indicating when the forecast was originally created. 
+  // The UTC timestamp indicating when the forecast was originally created.
   google.protobuf.Timestamp creation_ts = 3;
 }

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -30,7 +30,7 @@ service WeatherForecastService {
 
   // Streams live weather forecast features for a geo location as they become
   // available. Initially, the most recent forecast will be streamed.
-  rpc StreamLiveWeatherForecast (ForecastRequest)
+  rpc StreamLiveWeatherForecast (StreamLiveWeatherForecastRequest)
     returns (stream ForecastResponse);
 }
 
@@ -91,6 +91,18 @@ message GetHistoricalWeatherForecastRequest {
   // Specifies the maximum number of forecasts to be returned in a single
   // response.
   int32 page_size = 5;
+}
+
+// The StreamLiveWeatherForecastRequest message defines parameters for 
+// requesting live weather forecasts for a specified location, with designated
+// features.
+message StreamLiveWeatherForecastRequest {
+  // The location for which the forecast is being requested.
+  frequenz.api.common.location.Location location = 1;
+
+  // List of required features. If none are specified, all available features
+  // will be streamed.
+  repeated ForecastFeature features = 2;
 }
 
 // The ForecastResponse message encapsulates the weather forecast data returned


### PR DESCRIPTION
This PR refactors the ForecastRequest message, dividing it into two distinct Request messages to cater to two separate RPCs. This modification is driven by the fact that StreamLiveWeatherForecast RPC does not require start_ts, end_ts, and page_size. Furthermore, the documentation has been updated to specify that timestamps are now in UTC.

Fixes #18 and #21 