### PR TITLE
Add Pagination to the GetHistoricalWeatherForecast RPC

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,11 +5,10 @@
 
 ## Upgrading
 
-- The minimum supported Python version is now 3.11, you should update your project to at least this Python version.
 
 ## New Features
 
-- Add support to support requests for multiple locations in a single request.
+- Introduce Pagination to the historical RPC of the service.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -10,7 +10,9 @@ syntax = "proto3";
 
 package frequenz.api.weatherforecast.v1;
 
-import "frequenz/api/common/location.proto";
+import "frequenz/api/common/v1/location.proto";
+import "frequenz/api/common/v1/pagination/pagination_info.proto";
+import "frequenz/api/common/v1/pagination/pagination_params.proto";
 import "google/protobuf/timestamp.proto";
 
 
@@ -76,7 +78,7 @@ message GetHistoricalWeatherForecastRequest {
   // The locations for which the forecast is being requested.
   // The maximum number of locations that can be requested is 50. If the
   // request exceeds this limit, the API will respond with an error.
-  repeated frequenz.api.common.location.Location locations = 1;
+  repeated frequenz.api.common.v1.Location locations = 1;
 
   // List of required features. If none are specified, all available features
   // will be returned.
@@ -90,9 +92,11 @@ message GetHistoricalWeatherForecastRequest {
   // period.
   google.protobuf.Timestamp end_ts = 4;
 
-  // Specifies the maximum number of forecasts to be returned in a single
-  // response.
-  int32 page_size = 5;
+  // The parameters define the 'page_size' and the 'page_token'. An inital
+  // query of a request will omit the 'page_token'. Subsequent queries of the
+  // same request must include the 'page_token' from the previous response.
+  frequenz.api.common.v1.pagination.PaginationParams
+    pagination_params = 5;
 }
 
 // The `ReceiveLiveWeatherForecastRequest` message defines parameters for
@@ -102,7 +106,7 @@ message ReceiveLiveWeatherForecastRequest {
   // The locations for which the forecast is being requested.
   // The maximum number of locations that can be requested is 50. If the
   // request exceeds this limit, the API will respond with an error.
-  repeated frequenz.api.common.location.Location locations = 1;
+  repeated frequenz.api.common.v1.Location locations = 1;
 
   // List of required features. If none are specified, all available features
   // will be streamed.
@@ -138,7 +142,7 @@ message LocationForecast {
   repeated Forecasts forecasts = 1;
 
   // The location for which the weather data is returned.
-  frequenz.api.common.location.Location location = 2;
+  frequenz.api.common.v1.Location location = 2;
 
   // The UTC timestamp indicating when the forecast was originally created.
   google.protobuf.Timestamp creation_ts = 3;
@@ -148,6 +152,11 @@ message LocationForecast {
 // corresponding to a requested location.
 message GetHistoricalWeatherForecastResponse {
   repeated LocationForecast location_forecasts = 1;
+
+  // The pagination_info contains the number of 'total_items' in the response
+  // and the 'next_page_token' for the subsequent query of the request. It is
+  // omitted in the last response.
+  frequenz.api.common.v1.pagination.PaginationInfo pagination_info = 2;
 }
 
 // The message encapsulates a collection of live weather forecasts, each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.3.1, < 0.4.0",
+  "frequenz-api-common >= 0.5.0, < 0.6.0",
   "googleapis-common-protos >= 1.56.2, < 2",
   "grpcio >= 1.51.1, < 2",
 ]


### PR DESCRIPTION
This PR introduces pagination to the historical RPC. It also updates the needed submodule.