### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # Fallback owner.
 # These are the default owners for everything in the repo, unless a later match
 # takes precedence.
-* @frequenz-floss/api-team
+* @frequenz-floss/api-weather-team


### PR DESCRIPTION
Make the `api-weather-team` the default owner instead of `api-team`.