### PR TITLE
Provide a filter for validity times in the streaming method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,5 +10,7 @@
 
 - Introduce Pagination to the historical RPC of the service.
 
+- Allow filtering by validity when requesting for live or historical data.
+
 ## Bug Fixes
 

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -98,6 +98,11 @@ message GetHistoricalWeatherForecastRequest {
   // same request must include the 'page_token' from the previous response.
   frequenz.api.common.v1.pagination.PaginationParams
     pagination_params = 5;
+
+  // The validity times for which forecasts are being requested. These values
+  // should be relative to the generation time of the forecasts. When none are
+  // provided, forecasts for all available validity times will be returned.
+  repeated google.protobuf.Duration validity_times = 6;
 }
 
 // The `ReceiveLiveWeatherForecastRequest` message defines parameters for

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -13,6 +13,7 @@ package frequenz.api.weatherforecast.v1;
 import "frequenz/api/common/v1/location.proto";
 import "frequenz/api/common/v1/pagination/pagination_info.proto";
 import "frequenz/api/common/v1/pagination/pagination_params.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 
@@ -111,6 +112,11 @@ message ReceiveLiveWeatherForecastRequest {
   // List of required features. If none are specified, all available features
   // will be streamed.
   repeated ForecastFeature features = 2;
+
+  // The validity times for which forecasts are being requested. These values
+  // should be relative to the generation time of the forecasts. When none are
+  // provided, forecasts for all available validity times will be streamed.
+  repeated google.protobuf.Duration validity_times = 3;
 }
 
 // The `ForecastResponse` message  provides a structured format for representing


### PR DESCRIPTION
Some weather forecast sources provide data that look weeks ahead.  For use-cases that require just the forecasts for a shorter period like 24 hours ahead, it might be overkill to stream all available data, only to be discarded on the client.

This PR adds a request parameter for filtering validity times with, in the streaming method.