### PR TITLE
Add wind 10m uv component features to proto specs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
 
 - Introduce Pagination to the historical RPC of the service.
 
+- Add temperature 2m above ground.
+
 - Add eastward and northward components of wind speed at 10 m altitude.
 
 ## Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,5 +10,7 @@
 
 - Introduce Pagination to the historical RPC of the service.
 
+- Add eastward and northward components of wind speed at 10 m altitude.
+
 ## Bug Fixes
 

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -43,13 +43,18 @@ enum ForecastFeature {
   // Default value. When used, the API responds with all features listed below.
   FORECAST_FEATURE_UNSPECIFIED = 0;
 
+  // Temperature at 2 m altitude. It is the temperature of the air at a height
+  // of 2 metres above the surface of land, sea or in-land waters.
+  // Measured in Kelvin. To convert to Celsius, subtract 273.15.
+  FORECAST_FEATURE_TEMPERATURE_2_METRE = 1;
+
   // Eastward component of the wind at 100 m altitude. It is the horizontal
   // speed of air moving towards the east, at a height of 100 metres above the
   // surface of the Earth.
   // A positive value indicates eastward wind, and a negative value indicates
   // westward wind. Typical range is -20 to 20 m/s.
   // Measured in m/s.
-  FORECAST_FEATURE_U_WIND_COMPONENT_100_METRE = 1;
+  FORECAST_FEATURE_U_WIND_COMPONENT_100_METRE = 2;
 
   // Northward component wind at 100 m altitude. It is the horizontal speed of
   // air moving towards the north, at a height of 100 metres above the surface
@@ -57,7 +62,7 @@ enum ForecastFeature {
   // A positive value indicates northward wind, and a negative value indicates
   // southward wind. Typical range is -20 to 20 m/s.
   // Measured in m/s.
-  FORECAST_FEATURE_V_WIND_COMPONENT_100_METRE = 2;
+  FORECAST_FEATURE_V_WIND_COMPONENT_100_METRE = 3;
 
   // Eastward component wind at 10 m altitude. It is the horizontal speed of
   // air moving towards the east, at a height of 10 metres above the surface
@@ -66,7 +71,7 @@ enum ForecastFeature {
   // westward wind. Typical values are smaller than their 100 m counterparts
   // since it is stronger influenced by local terrain, vegetation and buildings.
   // Measured in m/s.
-  FORECAST_FEATURE_U_WIND_COMPONENT_10_METRE = 3;
+  FORECAST_FEATURE_U_WIND_COMPONENT_10_METRE = 4;
 
   // Northward component wind at 10 m altitude. It is the horizontal speed of
   // air moving towards the north, at a height of 100 metres above the surface
@@ -75,18 +80,18 @@ enum ForecastFeature {
   // southward wind. Typical values are smaller than their 100 m counterparts
   // since it is stronger influenced by local terrain, vegetation and buildings.
   // Measured in m/s.
-  FORECAST_FEATURE_V_WIND_COMPONENT_10_METRE = 4;
+  FORECAST_FEATURE_V_WIND_COMPONENT_10_METRE = 5;
 
   // Amount of solar radiation (shortwave radiation, direct and diffused) that
   // reaches a horizontal plane at the surface of the Earth.
   // Measured in W/m².
-  FORECAST_FEATURE_SURFACE_SOLAR_RADIATION_DOWNWARDS = 5;
+  FORECAST_FEATURE_SURFACE_SOLAR_RADIATION_DOWNWARDS = 6;
 
   // Amount of solar radiation (shortwave radiation, direct and diffused) that
   // reaches a horizontal plane at the surface of the Earth minus the amount
   // reflected by the Earth's surface (which is governed by the albedo).
   // Measured in W/m².
-  FORECAST_FEATURE_SURFACE_NET_SOLAR_RADIATION = 6;
+  FORECAST_FEATURE_SURFACE_NET_SOLAR_RADIATION = 7;
 }
 
 // The `GetHistoricalWeatherForecastRequest` message defines parameters for

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -59,16 +59,34 @@ enum ForecastFeature {
   // Measured in m/s.
   FORECAST_FEATURE_V_WIND_COMPONENT_100_METRE = 2;
 
+  // Eastward component wind at 10 m altitude. It is the horizontal speed of
+  // air moving towards the east, at a height of 10 metres above the surface
+  // of the Earth.
+  // A positive value indicates eastward wind, and a negative value indicates
+  // westward wind. Typical values are smaller than their 100 m counterparts
+  // since it is stronger influenced by local terrain, vegetation and buildings.
+  // Measured in m/s.
+  FORECAST_FEATURE_U_WIND_COMPONENT_10_METRE = 3;
+
+  // Northward component wind at 10 m altitude. It is the horizontal speed of
+  // air moving towards the north, at a height of 100 metres above the surface
+  // of the Earth.
+  // A positive value indicates northward wind, and a negative value indicates
+  // southward wind. Typical values are smaller than their 100 m counterparts
+  // since it is stronger influenced by local terrain, vegetation and buildings.
+  // Measured in m/s.
+  FORECAST_FEATURE_V_WIND_COMPONENT_10_METRE = 4;
+
   // Amount of solar radiation (shortwave radiation, direct and diffused) that
   // reaches a horizontal plane at the surface of the Earth.
   // Measured in W/m².
-  FORECAST_FEATURE_SURFACE_SOLAR_RADIATION_DOWNWARDS = 3;
+  FORECAST_FEATURE_SURFACE_SOLAR_RADIATION_DOWNWARDS = 5;
 
   // Amount of solar radiation (shortwave radiation, direct and diffused) that
   // reaches a horizontal plane at the surface of the Earth minus the amount
   // reflected by the Earth's surface (which is governed by the albedo).
   // Measured in W/m².
-  FORECAST_FEATURE_SURFACE_NET_SOLAR_RADIATION = 4;
+  FORECAST_FEATURE_SURFACE_NET_SOLAR_RADIATION = 6;
 }
 
 // The `GetHistoricalWeatherForecastRequest` message defines parameters for


### PR DESCRIPTION
This adds the northward and eastward components for wind at 10 m altitude.