### PR TITLE
Fix doc for 2m temperature in proto specs

### DIFF
--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -43,8 +43,9 @@ enum ForecastFeature {
   // Default value. When used, the API responds with all features listed below.
   FORECAST_FEATURE_UNSPECIFIED = 0;
 
-  // Temperature at 2 m altitude. It is the temperature of the air at a height
-  // of 2 metres above the surface of land, sea or in-land waters.
+  // Temperature at 2 m above the earth's surface. It is the temperature of
+  // the air at a height of 2 metres above the surface of land, sea or
+  // in-land waters.
   // Measured in Kelvin. To convert to Celsius, subtract 273.15.
   FORECAST_FEATURE_TEMPERATURE_2_METRE = 1;
 


### PR DESCRIPTION
Altitude usually refers to above sea level.