### PR TITLE
Add refined version for the to_ndarray_vfl() function #77

### DIFF
--- a/py/frequenz/client/weather/_types.py
+++ b/py/frequenz/client/weather/_types.py
@@ -147,7 +147,7 @@ class Forecasts:
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     def to_ndarray_vlf(
         self,
-        validity_times: list[dt.timedelta] | None = None,
+        validity_times: list[dt.datetime] | None = None,
         locations: list[Location] | None = None,
         features: list[ForecastFeature] | None = None,
     ) -> np.ndarray[
@@ -188,11 +188,6 @@ class Forecasts:
             validity_times_indexes = []
             feature_indexes = []
 
-            # get the creation timestamp for calculating the validity timedeltas
-            creation_ts = self._forecasts_pb.location_forecasts[
-                0
-            ].creation_ts.ToDatetime()
-
             # get the location indexes of the proto for the filtered locations
             if locations:
                 for location in locations:
@@ -211,9 +206,7 @@ class Forecasts:
                     for t_index, val_time in enumerate(
                         self._forecasts_pb.location_forecasts[0].forecasts
                     ):
-                        if req_validitiy_time == (
-                            val_time.valid_at_ts.ToDatetime() - creation_ts
-                        ):
+                        if req_validitiy_time == val_time.valid_at_ts.ToDatetime():
                             validity_times_indexes.append(t_index)
                             break
             else:
@@ -263,19 +256,21 @@ class Forecasts:
 
             # Check if the array shape matches the number of filtered times, locations
             # and features
-            if array.shape[0] != len(validity_times_indexes):
+            if validity_times is not None and array.shape[0] != len(validity_times):
                 print(
-                    f"Warning:  The count of validity times in the "
-                    f"array({array.shape[0]}) does not match the expected time "
-                    f"filter count ({validity_times_indexes}."
+                    (
+                        f"Warning:  The count of validity times in the "
+                        f"array({array.shape[0]}) does not match the expected time "
+                        f"filter count ({validity_times_indexes}."
+                    )
                 )
-            if array.shape[1] != len(location_indexes):
+            if locations is not None and array.shape[1] != len(location_indexes):
                 print(
                     f"Warning:  The count of location in the "
                     f"array ({array.shape[1]}) does not match the expected location "
                     f"filter count ({location_indexes})."
                 )
-            if array.shape[2] != len(feature_indexes):
+            if features is not None and array.shape[2] != len(feature_indexes):
                 print(
                     f"Warning: The count of features ({array.shape[2]}) does not "
                     f"match the feature filter count ({feature_indexes})."

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -179,6 +179,11 @@ class TestForecasts:
 
     """
 
+    valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
+    valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
+    valid_ts3 = datetime.fromisoformat("2024-01-01T02:00:00")
+    invalid_ts = datetime.fromisoformat("2024-01-02T03:00:00")
+
     def test_from_pb(
         self,
         forecastdata: tuple[
@@ -227,9 +232,7 @@ class TestForecasts:
         forecasts_proto, num_times, num_locations, num_features = forecastdata
         forecasts = Forecasts.from_pb(forecasts_proto)
 
-        valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
-        valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
-        validity_times = [valid_ts1, valid_ts2]
+        validity_times = [self.valid_ts1, self.valid_ts2]
 
         locations = [Location(latitude=42.0, longitude=18.0, country_code="US")]
         features = [
@@ -257,10 +260,7 @@ class TestForecasts:
         forecasts_proto, num_times, num_locations, num_features = forecastdata
         forecasts = Forecasts.from_pb(forecasts_proto)
 
-        valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
-        valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
-        valid_ts3 = datetime.fromisoformat("2024-01-01T02:00:00")
-        validity_times = [valid_ts1, valid_ts2, valid_ts3]
+        validity_times = [self.valid_ts1, self.valid_ts2, self.valid_ts3]
 
         locations = [
             Location(latitude=42.0, longitude=18.0, country_code="US"),
@@ -293,10 +293,7 @@ class TestForecasts:
         forecasts_proto, num_times, num_locations, num_features = forecastdata
         forecasts = Forecasts.from_pb(forecasts_proto)
 
-        valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
-        valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
-        invalid_ts = datetime.fromisoformat("2024-01-02T03:00:00")
-        validity_times = [valid_ts1, valid_ts2, invalid_ts]
+        validity_times = [self.valid_ts1, self.valid_ts2, self.invalid_ts]
 
         locations = [
             Location(latitude=50.0, longitude=18.0, country_code="US"),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -9,7 +9,7 @@
 # pylint doesn't understand the imports from the generated proto modules.
 # pylint: disable=no-name-in-module,no-member
 
-from datetime import timedelta
+from datetime import datetime
 
 import numpy as np
 from _pytest.logging import LogCaptureFixture
@@ -17,7 +17,7 @@ from frequenz.api.common.location_pb2 import Location as LocationProto
 from frequenz.api.weather import weather_pb2
 from frequenz.client.weather._types import ForecastFeature, Forecasts, Location
 from google.protobuf.timestamp_pb2 import Timestamp
-from pytest import fixture
+from pytest import CaptureFixture, fixture
 
 
 class TestForecastFeatureType:
@@ -227,7 +227,10 @@ class TestForecasts:
         forecasts_proto, num_times, num_locations, num_features = forecastdata
         forecasts = Forecasts.from_pb(forecasts_proto)
 
-        validity_times = [timedelta(hours=2), timedelta(hours=1)]
+        valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
+        valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
+        validity_times = [valid_ts1, valid_ts2]
+
         locations = [Location(latitude=42.0, longitude=18.0, country_code="US")]
         features = [
             ForecastFeature.V_WIND_COMPONENT_100_METRE,
@@ -254,7 +257,11 @@ class TestForecasts:
         forecasts_proto, num_times, num_locations, num_features = forecastdata
         forecasts = Forecasts.from_pb(forecasts_proto)
 
-        validity_times = [timedelta(hours=3), timedelta(hours=1)]
+        valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
+        valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
+        valid_ts3 = datetime.fromisoformat("2024-01-01T02:00:00")
+        validity_times = [valid_ts1, valid_ts2, valid_ts3]
+
         locations = [
             Location(latitude=42.0, longitude=18.0, country_code="US"),
             Location(latitude=43.0, longitude=19.0, country_code="CA"),
@@ -276,6 +283,7 @@ class TestForecasts:
 
     def test_to_ndarray_vlf_with_missing_parameters(
         self,
+        capsys: CaptureFixture,  # type: ignore
         forecastdata: tuple[
             weather_pb2.ReceiveLiveWeatherForecastResponse, int, int, int
         ],
@@ -285,7 +293,11 @@ class TestForecasts:
         forecasts_proto, num_times, num_locations, num_features = forecastdata
         forecasts = Forecasts.from_pb(forecasts_proto)
 
-        validity_times = [timedelta(hours=1), timedelta(hours=2), timedelta(days=1)]
+        valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
+        valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
+        invalid_ts = datetime.fromisoformat("2024-01-02T03:00:00")
+        validity_times = [valid_ts1, valid_ts2, invalid_ts]
+
         locations = [
             Location(latitude=50.0, longitude=18.0, country_code="US"),
             Location(latitude=43.0, longitude=19.0, country_code="CA"),
@@ -309,3 +321,6 @@ class TestForecasts:
             len(locations) - 1,
             len(features) - 1,
         )
+        assert array[0, 0, 0] == 100
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out


### PR DESCRIPTION
According to issue #77 a refined version of to_ndarray_vfl() to_ndarray_vfl_refined() was added to the repo. to_ndarray_vfl_refined() in comparision to the base function takes the validity_times to filter for in form of a list datetime Time objects instead of a list of timedelta relative to the request.