### PR TITLE
Extend the client to iterate over historical weather forecast data.

### DIFF
--- a/examples/iterate_hist_forecast.py
+++ b/examples/iterate_hist_forecast.py
@@ -1,0 +1,63 @@
+"""
+Iterates over historical Germany wind forecast data and prints it to the screen.
+
+Example run:
+PYTHONPATH=py python examples/iterate_hist_forecast.py "localhost:50051"
+
+License: MIT
+Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""
+
+import asyncio
+import datetime
+import sys
+
+import grpc.aio as grpcaio
+from frequenz.client.weather._client import Client
+from frequenz.client.weather._types import ForecastFeature, Location
+
+_service_address = sys.argv[1]
+
+
+async def main(service_address: str) -> None:
+    """Iterate over historical Germany wind forecast data and prints it to the screen.
+
+    Args:
+        service_address: The address of the service to connect to
+            given in a form of a host followed by a colon and a port.
+    """
+    client = Client(
+        grpcaio.insecure_channel(service_address),  # or secure channel with credentials
+        service_address,
+    )
+
+    features = [
+        ForecastFeature.V_WIND_COMPONENT_100_METRE,
+        ForecastFeature.U_WIND_COMPONENT_100_METRE,
+    ]
+
+    locations = [
+        Location(
+            latitude=52.5,
+            longitude=13.4,
+            country_code="DE",
+        ),
+    ]
+
+    now = datetime.datetime.utcnow()
+    start = now - datetime.timedelta(days=1000)
+    end = now + datetime.timedelta(days=0)
+
+    location_forecast_iterator = client.hist_forecast_iterator(
+        features=features, locations=locations, start=start, end=end
+    )
+
+    async for location_forecast in location_forecast_iterator:
+        for forecasts in location_forecast.forecasts:
+            print("Timestamp:", forecasts.valid_at_ts)
+            for feature_forecast in forecasts.features:
+                print(feature_forecast)
+
+
+asyncio.run(main(_service_address))

--- a/examples/stream_live_forecast.py
+++ b/examples/stream_live_forecast.py
@@ -1,0 +1,61 @@
+"""
+Streams live Germany wind forecast data.
+
+Example run:
+PYTHONPATH=py python examples/stream_live_forecast.py "localhost:50051"
+
+License: MIT
+Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+"""
+
+import asyncio
+import sys
+
+import grpc.aio as grpcaio
+from frequenz.client.weather._client import Client
+from frequenz.client.weather._types import ForecastFeature, Location
+
+_service_address = sys.argv[1]
+
+
+async def main(service_address: str) -> None:
+    """Stream live Germany wind forecast data.
+
+    Args:
+        service_address: The address of the service to connect to
+            given in a form of a host followed by a colon and a port.
+    """
+    client = Client(
+        grpcaio.insecure_channel(service_address),  # or secure channel with credentials
+        service_address,
+    )
+
+    features = [
+        ForecastFeature.V_WIND_COMPONENT_100_METRE,
+        ForecastFeature.U_WIND_COMPONENT_100_METRE,
+    ]
+
+    locations = [
+        Location(
+            latitude=52.5,
+            longitude=13.4,
+            country_code="DE",
+        ),
+    ]
+
+    stream = await client.stream_live_forecast(
+        features=features,
+        locations=locations,
+    )
+
+    async for fc in stream:
+        print(fc)
+        print(fc.to_ndarray_vlf())
+        print(
+            fc.to_ndarray_vlf(
+                features=[ForecastFeature.U_WIND_COMPONENT_100_METRE],
+            )
+        )
+
+
+asyncio.run(main(_service_address))

--- a/py/frequenz/client/weather/_client.py
+++ b/py/frequenz/client/weather/_client.py
@@ -3,11 +3,14 @@
 
 """The Weather Forecast API client."""
 
+from datetime import datetime
+
 import grpc
 from frequenz.api.weather import weather_pb2, weather_pb2_grpc
 from frequenz.channels import Receiver
 from frequenz.client.base.grpc_streaming_helper import GrpcStreamingHelper
 
+from ._historical_forecast_iterator import HistoricalForecastIterator
 from ._types import ForecastFeature, Forecasts, Location
 
 
@@ -58,3 +61,23 @@ class Client:
                 Forecasts.from_pb,
             )
         return self._streams[stream_key].new_receiver()
+
+    def hist_forecast_iterator(
+        self,
+        locations: list[Location],
+        features: list[ForecastFeature],
+        start: datetime,
+        end: datetime,
+    ) -> HistoricalForecastIterator:
+        """Stream historical weather forecast data.
+
+        Args:
+            locations: locations to stream data for.
+            features: features to stream data for.
+            start: start of the time range to stream data for.
+            end: end of the time range to stream data for.
+
+        Returns:
+            A channel receiver for weather forecast data.
+        """
+        return HistoricalForecastIterator(self._stub, locations, features, start, end)

--- a/py/frequenz/client/weather/_historical_forecast_iterator.py
+++ b/py/frequenz/client/weather/_historical_forecast_iterator.py
@@ -1,0 +1,93 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""The Historical Forecast Iterator."""
+
+from datetime import datetime
+from typing import Any, AsyncIterator, List
+
+from frequenz.api.common.pagination import pagination_params_pb2
+from frequenz.api.weather import weather_pb2, weather_pb2_grpc
+from google.protobuf import timestamp_pb2
+
+from ._types import ForecastFeature, Location
+
+PAGE_SIZE = 20
+EMPTY_PAGE_TOKEN = ""
+
+
+class HistoricalForecastIterator(AsyncIterator[weather_pb2.LocationForecast]):
+    """An iterator over historical weather forecasts."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        stub: weather_pb2_grpc.WeatherForecastServiceStub,
+        locations: list[Location],
+        features: list[ForecastFeature],
+        start: datetime,
+        end: datetime,
+    ) -> None:
+        """Initialize the iterator.
+
+        Args:
+            stub: The gRPC stub to use for communication with the API.
+            locations: Locations to get historical weather forecasts for.
+            features: Features to get historical weather forecasts for.
+            start: Start of the time range to get historical weather forecasts for.
+            end: End of the time range to get historical weather forecasts for.
+        """
+        self._stub = stub
+        self.locations = locations
+        self.features = features
+
+        self.start_ts = timestamp_pb2.Timestamp()
+        self.start_ts.FromDatetime(start)
+        self.end_ts = timestamp_pb2.Timestamp()
+        self.end_ts.FromDatetime(end)
+
+        self.location_forecasts: List[weather_pb2.LocationForecast] = []
+        self.page_token = None
+
+    def __aiter__(self) -> "HistoricalForecastIterator":
+        """Return the iterator.
+
+        Returns:
+            The iterator.
+        """
+        return self
+
+    async def __anext__(self) -> weather_pb2.LocationForecast:
+        """Get the next historical weather forecast.
+
+        Returns:
+            The next historical weather forecast.
+
+        Raises:
+            StopAsyncIteration: If there are no more historical weather forecasts.
+        """
+        if len(self.location_forecasts) == 0 and self.page_token == EMPTY_PAGE_TOKEN:
+            raise StopAsyncIteration
+
+        if self.location_forecasts is None or len(self.location_forecasts) == 0:
+            pagination_params = pagination_params_pb2.PaginationParams()
+            pagination_params.page_size = PAGE_SIZE
+            if self.page_token is not None:
+                pagination_params.page_token = self.page_token
+
+            response: Any = (
+                await self._stub.GetHistoricalWeatherForecast(  # type:ignore
+                    weather_pb2.GetHistoricalWeatherForecastRequest(
+                        locations=(location.to_pb() for location in self.locations),
+                        features=(feature.value for feature in self.features),
+                        start_ts=self.start_ts,
+                        end_ts=self.end_ts,
+                        pagination_params=pagination_params,
+                    )
+                )
+            )
+
+            self.page_token = response.pagination_info.next_page_token
+            self.location_forecasts = response.location_forecasts
+
+        location_forecast: weather_pb2.LocationForecast = self.location_forecasts.pop(0)
+        return location_forecast


### PR DESCRIPTION
Extend the client to iterate over historical weather forecast data.

Add examples to demonstrate:
- How to stream live data with the client based on [Christoph's example](https://github.com/frequenz-floss/frequenz-api-weather/issues/83#issuecomment-1968911497).
- How to iterate over the historical data with the client.

Example output from the second example:
```
Timestamp: seconds: 1702940400

feature: FORECAST_FEATURE_V_WIND_COMPONENT_100_METRE
value: 5.11610031

feature: FORECAST_FEATURE_U_WIND_COMPONENT_100_METRE
value: 12.4870567

Timestamp: seconds: 1702944000

feature: FORECAST_FEATURE_V_WIND_COMPONENT_100_METRE
value: 5.08150578

feature: FORECAST_FEATURE_U_WIND_COMPONENT_100_METRE
value: 12.0456848
```