### PR TITLE
Update `frequenz-client-base` version and prepare for v0.3.0 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,16 @@
 
 ## Summary
 
+This release includes a breaking change to how `validity_times` are specified in
+calls to `Forecasts.to_ndarray_vlf`.  It also includes a couple of dependency
+updates.
+
 ## Upgrading
+
+- The required `channels` package version is now updated to `1.0.0b2`
+
+- `validity_times` in the `to_ndarray_vlf` method on received `Forecasts` is now
+  specified as a list of `datetime`s, and no longer a list of `timedelta`s.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,19 +2,10 @@
 
 ## Summary
 
-This release of the Frequenz Weather API adds support for streaming new
-temperature and wind speed forecasts.
-
 ## Upgrading
 
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
-
-- Add temperature 2m above ground.
-
-- Add eastward and northward components of wind speed at 10 m altitude.
-
-- Update the client to support the new temperature and 10m wind features.
 
 ## Bug Fixes

--- a/py/frequenz/client/weather/_client.py
+++ b/py/frequenz/client/weather/_client.py
@@ -6,7 +6,7 @@
 import grpc
 from frequenz.api.weather import weather_pb2, weather_pb2_grpc
 from frequenz.channels import Receiver
-from frequenz.client.base.grpc_streaming_helper import GrpcStreamingHelper
+from frequenz.client.base.streaming import GrpcStreamBroadcaster
 
 from ._types import ForecastFeature, Forecasts, Location
 
@@ -25,7 +25,7 @@ class Client:
         self._stub = weather_pb2_grpc.WeatherForecastServiceStub(grpc_channel)
         self._streams: dict[
             tuple[Location | ForecastFeature, ...],
-            GrpcStreamingHelper[
+            GrpcStreamBroadcaster[
                 weather_pb2.ReceiveLiveWeatherForecastResponse, Forecasts
             ],
         ] = {}
@@ -47,7 +47,7 @@ class Client:
         stream_key = tuple(tuple(locations) + tuple(features))
 
         if stream_key not in self._streams:
-            self._streams[stream_key] = GrpcStreamingHelper(
+            self._streams[stream_key] = GrpcStreamBroadcaster(
                 f"weather-forecast-{stream_key}",
                 lambda: self._stub.ReceiveLiveWeatherForecast(  # type:ignore
                     weather_pb2.ReceiveLiveWeatherForecastRequest(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "googleapis-common-protos >= 1.62.0, < 2",
   "grpcio >= 1.54.2, < 2",
-  "frequenz-channels >= 0.16.0, < 0.17.0",
-  "frequenz-client-base >= 0.1.0, < 0.2",
+  "frequenz-channels == 1.0.0b2",
+  "frequenz-client-base >= 0.2.0, < 0.3",
   "numpy >= 1.24.2, < 2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This PR updates `frequenz-client-base` to 0.2, so that we can update the `channels` requirement to 1.0.0b2.

It also prepares the release notes for a 0.3.0 release.