### PR TITLE
Convert a page of historical location forecast data into a flattened numpy array for easier use

### DIFF
--- a/py/frequenz/client/weather/_types.py
+++ b/py/frequenz/client/weather/_types.py
@@ -303,7 +303,6 @@ class HistoricalForecasts:
         """
         return cls(_forecasts_pb=forecasts)
 
-    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
     def flatten(
         self,
     ) -> np.ndarray[
@@ -325,7 +324,6 @@ class HistoricalForecasts:
         return flatten(list(self._forecasts_pb.location_forecasts))
 
 
-# pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def flatten(
     location_forecasts: list[weather_pb2.LocationForecast],
 ) -> np.ndarray[


### PR DESCRIPTION
- Enable the conversion of protobuf LocationForecast list to a flattened numpy
  array.
- Enhance the historical data retrieval example with conversion to
  a pandas dataframe, sample output:
```
(sdk_venv22) david@david-desktop:~/projects/frequenz/source/frequenz-api-weather$ PYTHONPATH=py python examples/iterate_hist_forecast.py "localhost:50051"
            creation_ts latitude longitude         valid_at_ts                                     feature      value
0   2022-06-27 12:00:00     52.5      13.4 2022-06-27 13:00:00  ForecastFeature.U_WIND_COMPONENT_100_METRE  -2.629823
1   2022-06-27 12:00:00     52.5      13.4 2022-06-27 13:00:00  ForecastFeature.V_WIND_COMPONENT_100_METRE   2.316034
2   2022-06-27 12:00:00     52.5      13.4 2022-06-27 14:00:00  ForecastFeature.U_WIND_COMPONENT_100_METRE  -2.439865
3   2022-06-27 12:00:00     52.5      13.4 2022-06-27 14:00:00  ForecastFeature.V_WIND_COMPONENT_100_METRE   1.965858
4   2022-06-27 12:00:00     52.5      13.4 2022-06-27 15:00:00  ForecastFeature.U_WIND_COMPONENT_100_METRE    -1.6119
..                  ...      ...       ...                 ...                                         ...        ...
337 2023-12-18 00:00:00     52.5      13.4 2023-12-18 22:00:00  ForecastFeature.V_WIND_COMPONENT_100_METRE   4.606584
338 2023-12-18 00:00:00     52.5      13.4 2023-12-18 23:00:00  ForecastFeature.U_WIND_COMPONENT_100_METRE  11.596823
339 2023-12-18 00:00:00     52.5      13.4 2023-12-18 23:00:00  ForecastFeature.V_WIND_COMPONENT_100_METRE   4.560944
340 2023-12-18 00:00:00     52.5      13.4 2023-12-19 00:00:00  ForecastFeature.U_WIND_COMPONENT_100_METRE  11.380841
341 2023-12-18 00:00:00     52.5      13.4 2023-12-19 00:00:00  ForecastFeature.V_WIND_COMPONENT_100_METRE   4.240217

[342 rows x 6 columns]
```

Closes https://github.com/frequenz-floss/frequenz-api-weather/issues/88.