### PR TITLE
Clear release notes from v0.3.0 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,16 +2,7 @@
 
 ## Summary
 
-This release includes a breaking change to how `validity_times` are specified in
-calls to `Forecasts.to_ndarray_vlf`.  It also includes a couple of dependency
-updates.
-
 ## Upgrading
-
-- The required `channels` package version is now updated to `1.0.0b2`
-
-- `validity_times` in the `to_ndarray_vlf` method on received `Forecasts` is now
-  specified as a list of `datetime`s, and no longer a list of `timedelta`s.
 
 - The location and pagination proto files are now again imported from the
  ´frequenz-api-common´ submodule instead of being imported from local files.


### PR DESCRIPTION
Removing notes that were already released with v0.3.0