### PR TITLE
Update frequenz-client-base to 0.3.x

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
 
 - The required version of the ´frequenz-channels` is updated to 1.0.0.
 
+- The required version of the ´frequenz-client-base` dependency is updated to v0.3.x.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "googleapis-common-protos >= 1.62.0, < 2",
   "grpcio >= 1.54.2, < 2",
   "frequenz-channels == 1.0.0",
-  "frequenz-client-base >= 0.2.0, < 0.3",
+  "frequenz-client-base >= 0.3.0, < 0.4",
   "numpy >= 1.24.2, < 2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Update frequenz-client-base to 0.3.x to allow using it with latest SDK v1.0.0rc6 (requires microgrid v0.3 requires client-base v0.3) 