### PR TITLE
Update minimum version of `frequenz-client-base` to 0.4.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The minimum required version of `frequenz-client-base` is now 0.4.0
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "googleapis-common-protos >= 1.62.0, < 2",
   "grpcio >= 1.54.2, < 2",
   "frequenz-channels >= 1.0.0, < 2",
-  "frequenz-client-base >= 0.3.0, < 0.4",
+  "frequenz-client-base >= 0.4.0, < 0.5",
   "numpy >= 1.24.2, < 2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Done to be compatible with `frequenz-sdk-python >= v1.0.0rc700`.