### PR TITLE
Change handling of missing data in to_array_vlf method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,7 @@
 
 ## Upgrading
 
-- The minimum required version of `frequenz-client-base` is now 0.6.0.
+* The `to_array_vlf` method now returns an array with the requested shape
+  where missing data is set to `NaN`. This is a change in behavior and
+  might require adjustments in the calling code, whereby the previous
+  behavior could not be used in a reliable way.

--- a/py/frequenz/client/weather/_types.py
+++ b/py/frequenz/client/weather/_types.py
@@ -276,23 +276,19 @@ class Forecasts:
             # Check if the array shape matches the number of filtered times, locations
             # and features
             if validity_times is not None and array.shape[0] != len(validity_times):
-                print(
-                    (
-                        f"Warning:  The count of validity times in the "
-                        f"array({array.shape[0]}) does not match the expected time "
-                        f"filter count ({validity_times_indexes}."
-                    )
+                raise ValueError(
+                    f"The count of validity times in the array({array.shape[0]}) does "
+                    f"not match the requested validity times count ({validity_times}."
                 )
-            if locations is not None and array.shape[1] != len(location_indexes):
-                print(
-                    f"Warning:  The count of location in the "
-                    f"array ({array.shape[1]}) does not match the expected location "
-                    f"filter count ({location_indexes})."
+            if locations is not None and array.shape[1] != len(locations):
+                raise ValueError(
+                    f"The count of location in the array ({array.shape[1]}) does not "
+                    f"match the requested location count ({locations})."
                 )
-            if features is not None and array.shape[2] != len(feature_indexes):
-                print(
-                    f"Warning: The count of features ({array.shape[2]}) does not "
-                    f"match the feature filter count ({feature_indexes})."
+            if features is not None and array.shape[2] != len(features):
+                raise ValueError(
+                    f"The count of features in the array ({array.shape[2]}) does not "
+                    f"match the requested feature count ({features})."
                 )
 
         # catch all exceptions

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -181,7 +181,7 @@ class TestForecasts:
 
     valid_ts1 = datetime.fromisoformat("2024-01-01T01:00:00")
     valid_ts2 = datetime.fromisoformat("2024-01-01T02:00:00")
-    valid_ts3 = datetime.fromisoformat("2024-01-01T02:00:00")
+    valid_ts3 = datetime.fromisoformat("2024-01-01T03:00:00")
     invalid_ts = datetime.fromisoformat("2024-01-02T03:00:00")
 
     def test_from_pb(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -99,71 +99,77 @@ def forecastdata() -> (  # pylint: disable=too-many-locals
     Returns: tuple of example ReceiveLiveWeatherForecastResponse proto object,
     number of times, number of locations, number of features
     """
-    # Create a list of FeatureForecast objects (replace with actual FeatureForecast objects)
-    feature_forecasts_list = []
-    some_feature_values = [
-        weather_pb2.ForecastFeature.FORECAST_FEATURE_U_WIND_COMPONENT_100_METRE,
-        weather_pb2.ForecastFeature.FORECAST_FEATURE_V_WIND_COMPONENT_100_METRE,
-        weather_pb2.ForecastFeature.FORECAST_FEATURE_SURFACE_SOLAR_RADIATION_DOWNWARDS,
-    ]
-    some_float_values = [100, 200, 300]
-
-    for feature, value in zip(some_feature_values, some_float_values):
-        forecast = weather_pb2.LocationForecast.Forecasts.FeatureForecast(
-            feature=feature, value=value
-        )
-        feature_forecasts_list.append(forecast)
-
-    many_forecasts = []
-
-    # adding different valid_ts into valid_ts_list
-
-    valid_ts1 = Timestamp()
-    valid_ts1.FromJsonString("2024-01-01T01:00:00Z")
-
-    valid_ts2 = Timestamp()
-    valid_ts2.FromJsonString("2024-01-01T02:00:00Z")
-
-    valid_ts3 = Timestamp()
-    valid_ts3.FromJsonString("2024-01-01T03:00:00Z")
-
-    valid_ts_list = [valid_ts1, valid_ts2, valid_ts3]
-
-    # adding same forecast for different valid_ts into many_forecasts
-
-    for valid_ts in valid_ts_list:
-        full_features_forecasts = weather_pb2.LocationForecast.Forecasts(
-            valid_at_ts=valid_ts, features=feature_forecasts_list
-        )
-        many_forecasts.append(full_features_forecasts)
-
-    some_locations_forecasts = []
-
-    some_creation_ts = Timestamp()
-    some_creation_ts.FromJsonString("2024-01-01T00:00:00Z")
-
-    # adding different locations into locations_list
+    # Create example data
     locations = [
         LocationProto(latitude=42.0, longitude=18.0, country_code="US"),
         LocationProto(latitude=43.0, longitude=19.0, country_code="CA"),
     ]
+    valid_times = [
+        datetime.fromisoformat("2024-01-01T01:00:00"),
+        datetime.fromisoformat("2024-01-01T02:00:00"),
+        datetime.fromisoformat("2024-01-01T03:00:00"),
+    ]
+    feature_list = [
+        weather_pb2.ForecastFeature.FORECAST_FEATURE_U_WIND_COMPONENT_100_METRE,
+        weather_pb2.ForecastFeature.FORECAST_FEATURE_V_WIND_COMPONENT_100_METRE,
+        weather_pb2.ForecastFeature.FORECAST_FEATURE_SURFACE_SOLAR_RADIATION_DOWNWARDS,
+    ]
 
-    for location in locations:
+    # Convert to Timestamp objects
+    valid_tstamps = []
+    for time in valid_times:
+        ts = Timestamp()
+        ts.FromDatetime(time)
+        valid_tstamps.append(ts)
+
+    num_locations = len(locations)
+    num_times = len(valid_tstamps)
+    num_features = len(feature_list)
+
+    # Create the creation timestamp
+    creation_ts = Timestamp()
+    creation_ts.FromDatetime(valid_times[0])
+
+    # Initialize list to hold location forecasts
+    location_forecasts = []
+
+    # Loop over locations
+    for loc_idx, location in enumerate(locations):
+        forecasts = []
+
+        # Loop over valid times
+        for time_idx, valid_ts in enumerate(valid_tstamps):
+            feature_forecasts = []
+
+            # Different feature values only on features dimension
+            feature_values = [100, 200, 300]
+
+            # Loop over features and their corresponding values
+            for feature, value in zip(feature_list, feature_values):
+                # Create the FeatureForecast object
+                feature_forecast = (
+                    weather_pb2.LocationForecast.Forecasts.FeatureForecast(
+                        feature=feature, value=value
+                    )
+                )
+                feature_forecasts.append(feature_forecast)
+
+            # Create the Forecasts object for the current time
+            forecast = weather_pb2.LocationForecast.Forecasts(
+                valid_at_ts=valid_ts, features=feature_forecasts
+            )
+            forecasts.append(forecast)
+
+        # Create the LocationForecast object for the current location
         location_forecast = weather_pb2.LocationForecast(
-            forecasts=many_forecasts,
-            location=location,
-            creation_ts=some_creation_ts,
+            forecasts=forecasts, location=location, creation_ts=creation_ts
         )
-        some_locations_forecasts.append(location_forecast)
+        location_forecasts.append(location_forecast)
 
-    # creating a ReceiveLiveWeatherForecastResponse proto object
+    # Create the ReceiveLiveWeatherForecastResponse proto object
     forecasts_proto = weather_pb2.ReceiveLiveWeatherForecastResponse(
-        location_forecasts=some_locations_forecasts
+        location_forecasts=location_forecasts
     )
-
-    num_times = 3
-    num_locations = 2
-    num_features = 3
 
     return forecasts_proto, num_times, num_locations, num_features
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -220,6 +220,7 @@ class TestForecasts:
             num_features,
         )
         assert array[0, 0, 0] == 100
+        assert array[1, 0, 0] == 100
 
     def test_to_ndarray_vlf_with_some_parameters(
         self,
@@ -235,6 +236,7 @@ class TestForecasts:
         validity_times = [self.valid_ts1, self.valid_ts2]
 
         locations = [Location(latitude=42.0, longitude=18.0, country_code="US")]
+        # Note order of features in query is different from order in proto
         features = [
             ForecastFeature.V_WIND_COMPONENT_100_METRE,
             ForecastFeature.U_WIND_COMPONENT_100_METRE,
@@ -247,7 +249,11 @@ class TestForecasts:
         # checks if output is a numpy array and matches expected shape
         assert isinstance(array, np.ndarray)
         assert array.shape == (len(validity_times), len(locations), len(features))
+        # Note order of features in query is different from order in proto
         assert array[0, 0, 0] == 200
+        assert array[0, 0, 1] == 100
+        assert array[1, 0, 0] == 200
+        assert array[1, 0, 1] == 100
 
     def test_to_ndarray_vlf_with_all_parameters(
         self,
@@ -289,13 +295,15 @@ class TestForecasts:
         ],
     ) -> None:
         """Test if the to_ndarray method works correctly when filter parameters are missing."""
-        # create an example Forecasts object with 3 times, 2 locations and 3 features
+        # create an example Forecasts object with 3 times, 2 locations and 4 features
+        # where each dimension contains one key without data
         forecasts_proto, num_times, num_locations, num_features = forecastdata
         forecasts = Forecasts.from_pb(forecasts_proto)
 
         validity_times = [self.valid_ts1, self.valid_ts2, self.invalid_ts]
 
         locations = [
+            # this location has no data in proto
             Location(latitude=50.0, longitude=18.0, country_code="US"),
             Location(latitude=43.0, longitude=19.0, country_code="CA"),
         ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -332,6 +332,27 @@ class TestForecasts:
             len(locations) - 1,
             len(features) - 1,
         )
+        assert not np.isnan(array).any()
+
         assert array[0, 0, 0] == 10
+        assert array[0, 0, 1] == 11
+        assert array[0, 0, 2] == 12
+        assert array[1, 0, 0] == 110
+        assert array[1, 0, 1] == 111
+        assert array[1, 0, 2] == 112
+
+        # Needs fixing: We change the position of the invalid timestamp
+        # and still receive the same result.
+        validity_times = [self.invalid_ts, self.valid_ts1, self.valid_ts2]
+        array = forecasts.to_ndarray_vlf(
+            validity_times=validity_times, locations=locations, features=features
+        )
+        assert array[0, 0, 0] == 10
+        assert array[0, 0, 1] == 11
+        assert array[0, 0, 2] == 12
+        assert array[1, 0, 0] == 110
+        assert array[1, 0, 1] == 111
+        assert array[1, 0, 2] == 112
+
         captured = capsys.readouterr()
         assert "Warning" in captured.out

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -141,11 +141,11 @@ def forecastdata() -> (  # pylint: disable=too-many-locals
         for time_idx, valid_ts in enumerate(valid_tstamps):
             feature_forecasts = []
 
-            # Different feature values only on features dimension
-            feature_values = [100, 200, 300]
+            # Loop over features
+            for feature_idx, feature in enumerate(feature_list):
+                # Create distinct values for each combination (acc to indexing)
+                value = 1 * feature_idx + 100 * time_idx + 10 * loc_idx
 
-            # Loop over features and their corresponding values
-            for feature, value in zip(feature_list, feature_values):
                 # Create the FeatureForecast object
                 feature_forecast = (
                     weather_pb2.LocationForecast.Forecasts.FeatureForecast(
@@ -225,7 +225,7 @@ class TestForecasts:
             num_locations,
             num_features,
         )
-        assert array[0, 0, 0] == 100
+        assert array[0, 0, 0] == 0
         assert array[1, 0, 0] == 100
 
     def test_to_ndarray_vlf_with_some_parameters(
@@ -256,9 +256,9 @@ class TestForecasts:
         assert isinstance(array, np.ndarray)
         assert array.shape == (len(validity_times), len(locations), len(features))
         # Note order of features in query is different from order in proto
-        assert array[0, 0, 0] == 200
-        assert array[0, 0, 1] == 100
-        assert array[1, 0, 0] == 200
+        assert array[0, 0, 0] == 1
+        assert array[0, 0, 1] == 0
+        assert array[1, 0, 0] == 101
         assert array[1, 0, 1] == 100
 
     def test_to_ndarray_vlf_with_all_parameters(
@@ -332,6 +332,6 @@ class TestForecasts:
             len(locations) - 1,
             len(features) - 1,
         )
-        assert array[0, 0, 0] == 100
+        assert array[0, 0, 0] == 10
         captured = capsys.readouterr()
         assert "Warning" in captured.out


### PR DESCRIPTION
The implementation of `to_array_vlf` is problematic since it skips missing keys in any of the dimensions and it is not possible to derive for which key data was missing. For instance, if not all requested validity times are available, the method will only return the available ones and the user does not know for which validity times the data was missing.

This changes the behavior of the method such that the shape always matches the requested size and all entries where data is missing are set to `NaN`.

In addition to that unit tests for the method are extended.