### PR TITLE
Upgrade common API version to v0.6.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz Weather API Release Notes
 
-## Summary
+## ## Upgrading
 
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- The minimum required version of `frequenz-api-common` is now v0.6.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
   "frequenz-repo-config[api] == 0.9.2",
+  # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
+  # sure the code is generated using the minimum supported versions, as older
+  # versions can't work with code that was generated with newer versions.
+  # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
+  "protobuf == 4.25.3",
+  "grpcio-tools == 1.51.1",
+  "grpcio == 1.51.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -27,11 +34,17 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-common >= 0.5.4, < 0.6.0",
-  "googleapis-common-protos >= 1.65.0, < 2",
-  "grpcio >= 1.66.1, < 2",
+  "googleapis-common-protos >= 1.56.4, < 2",
   "frequenz-channels >= 1.0.0, < 2",
   "frequenz-client-base >= 0.6.0, < 0.7",
   "numpy >= 1.24.2, < 2",
+  # We can't widen beyond 6 because of protobuf cross-version runtime guarantees
+  # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
+  "protobuf >= 4.25.3, < 6", # Do not widen beyond 6!
+  # We couldn't find any document with a spec about the cross-version runtime
+  # guarantee for grpcio, so unless we find one in the future, we'll assume
+  # major version jumps are not compatible
+  "grpcio >= 1.54.2, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.5.4, < 0.6.0",
+  "frequenz-api-common >= 0.6.0, < 0.7.0",
   "googleapis-common-protos >= 1.56.4, < 2",
   "frequenz-channels >= 1.0.0, < 2",
   "frequenz-client-base >= 0.6.0, < 0.7",


### PR DESCRIPTION
This would allow the weather client to be used with the reporting client.  The SDK already uses common API v0.6.0, so after this, the weather client will continue to remain compatible with the SDK.