### PR TITLE
Add `forecast_horizon` range to the protobuf definitions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,11 @@
 
 ## New Features
 
+* Added optional `forecast_horizon_min` and `forecast_horizon_max` parameter
+  to `ReceiveLiveWeatherForecastRequest` that allows limiting the forecast
+  horizon of returned forecasts. When not specified, forecasts with their
+  minimum/maximum available horizon will be returned.
+
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -139,6 +139,18 @@ message ReceiveLiveWeatherForecastRequest {
   // List of required features. If none are specified, all available features
   // will be streamed.
   repeated ForecastFeature features = 2;
+
+  // Minimum forecast horizon (in hours) to include in the returned forecasts.
+  // Each forecast predicts weather conditions for a certain time span into the
+  // future (the forecast horizon). If not specified, forecasts starting from
+  // the earliest available horizon will be returned.
+  optional uint32 forecast_horizon_min = 3;
+
+  // Maximum forecast horizon (in hours) to include in the returned forecasts.
+  // If not specified, forecasts up to their maximum available horizon will be
+  // returned. If the requested horizon exceeds the available forecast data,
+  // the maximum available horizon will be used.
+  optional uint32 forecast_horizon_max = 4;
 }
 
 // The `ForecastResponse` message  provides a structured format for representing


### PR DESCRIPTION
This PR introduces two new optional fields in the `ReceiveLiveWeatherForecastRequest` named `forecast_horizon_min` and `forecast_horizon_max`. This field introduces the ability to limit the forecast horizon of the received forecasts.  