### PR TITLE
Replace pagination in historical RPC with streaming and update naming

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,10 @@ The weather client and CLI tool are no longer included in this package. To
 continue using them, migrate to frequenz-client-weather-python. Follow
 the installation and usage instructions provided in the new repository.
 
+- The parameters for the historical RCP changed from `start_ts` to `creation_start_ts` and from `end_ts` to `creation_end_ts`.
+
+- The historical RPC replaced pagination with streaming.
+
 ## New Features
 
 ## Bug Fixes

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -112,13 +112,13 @@ message GetHistoricalWeatherForecastRequest {
   // will be returned.
   repeated ForecastFeature features = 2;
 
-  // The UTC timestamp indicating the start of the requested historical forecast
-  // period.
-  google.protobuf.Timestamp start_ts = 3;
+  // The start of the forecast creation time range to query. Only forecasts
+  // created at or after this UTC timestamp will be included.
+  google.protobuf.Timestamp creation_start_ts = 3;
 
-  // The UTC timestamp indicating the end of the requested historical forecast
-  // period.
-  google.protobuf.Timestamp end_ts = 4;
+  // The end of the forecast creation time range to query. Only forecasts
+  // created before this UTC timestamp will be included.
+  google.protobuf.Timestamp creation_end_ts = 4;
 
   // The parameters define the 'page_size' and the 'page_token'. An inital
   // query of a request will omit the 'page_token'. Subsequent queries of the

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -13,8 +13,6 @@ package frequenz.api.weatherforecast.v1;
 import "google/protobuf/timestamp.proto";
 
 import "frequenz/api/common/v1/location.proto";
-import "frequenz/api/common/v1/pagination/pagination_info.proto";
-import "frequenz/api/common/v1/pagination/pagination_params.proto";
 
 // Service provides operations related to retrieving weather forecasts for
 // locations.
@@ -27,8 +25,8 @@ import "frequenz/api/common/v1/pagination/pagination_params.proto";
 service WeatherForecastService {
   // Returns historical weather forecast features for a geo location for a
   // specified time range.
-  rpc GetHistoricalWeatherForecast (GetHistoricalWeatherForecastRequest)
-    returns (GetHistoricalWeatherForecastResponse);
+  rpc ReceiveHistoricalWeatherForecast (ReceiveHistoricalWeatherForecastRequest)
+    returns (stream ReceiveHistoricalWeatherForecastResponse);
 
   // Streams live weather forecast features for a geo location as they become
   // available. Initially, the most recent forecast will be streamed.
@@ -99,10 +97,10 @@ enum ForecastFeature {
   FORECAST_FEATURE_SURFACE_NET_SOLAR_RADIATION = 7;
 }
 
-// The `GetHistoricalWeatherForecastRequest` message defines parameters for
+// The `ReceiveHistoricalWeatherForecastRequest` message defines parameters for
 // retrieving historical weather forecasts, targeting a specific location
 // and time period, with designated features.
-message GetHistoricalWeatherForecastRequest {
+message ReceiveHistoricalWeatherForecastRequest {
   // The locations for which the forecast is being requested.
   // The maximum number of locations that can be requested is 50. If the
   // request exceeds this limit, the API will respond with an error.
@@ -119,12 +117,6 @@ message GetHistoricalWeatherForecastRequest {
   // The end of the forecast creation time range to query. Only forecasts
   // created before this UTC timestamp will be included.
   google.protobuf.Timestamp creation_end_ts = 4;
-
-  // The parameters define the 'page_size' and the 'page_token'. An inital
-  // query of a request will omit the 'page_token'. Subsequent queries of the
-  // same request must include the 'page_token' from the previous response.
-  frequenz.api.common.v1.pagination.PaginationParams
-    pagination_params = 5;
 }
 
 // The `ReceiveLiveWeatherForecastRequest` message defines parameters for
@@ -190,13 +182,8 @@ message LocationForecast {
 
 // The message encapsulates a collection of historical weather forecasts, each
 // corresponding to a requested location.
-message GetHistoricalWeatherForecastResponse {
+message ReceiveHistoricalWeatherForecastResponse {
   repeated LocationForecast location_forecasts = 1;
-
-  // The pagination_info contains the number of 'total_items' in the response
-  // and the 'next_page_token' for the subsequent query of the request. It is
-  // omitted in the last response.
-  frequenz.api.common.v1.pagination.PaginationInfo pagination_info = 2;
 }
 
 // The message encapsulates a collection of live weather forecasts, each


### PR DESCRIPTION
This PR introduces streaming to the historical RPC. Therefore, the pagination is removed. Additionally, the start timestamp and end timestamp parameters in the historical RPC request message are renamed and their meaning clarified.