### PR TITLE
Add `forecast_horizon` range to historical RPC

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,10 @@ the installation and usage instructions provided in the new repository.
 
 - The historical RPC replaced pagination with streaming.
 
+- Added optional `forecast_horizon_min` and `forecast_horizon_max` parameter
+  to `ReceiveHistoricalWeatherForecastRequest` that allows limiting the forecast
+  horizon of returned forecasts.
+
 ## New Features
 
 ## Bug Fixes

--- a/proto/frequenz/api/weather/weather.proto
+++ b/proto/frequenz/api/weather/weather.proto
@@ -117,6 +117,18 @@ message ReceiveHistoricalWeatherForecastRequest {
   // The end of the forecast creation time range to query. Only forecasts
   // created before this UTC timestamp will be included.
   google.protobuf.Timestamp creation_end_ts = 4;
+
+  // Minimum forecast horizon (in hours) to include in the returned forecasts.
+  // Each forecast predicts weather conditions for a certain time span into the
+  // future (the forecast horizon). If not specified, forecasts starting from
+  // the earliest available horizon will be returned.
+  optional uint32 forecast_horizon_min = 5;
+
+  // Maximum forecast horizon (in hours) to include in the returned forecasts.
+  // If not specified, forecasts up to their maximum available horizon will be
+  // returned. If the requested horizon exceeds the available forecast data,
+  // the maximum available horizon will be used.
+  optional uint32 forecast_horizon_max = 6;
 }
 
 // The `ReceiveLiveWeatherForecastRequest` message defines parameters for


### PR DESCRIPTION
This PR introduces two new optional fields in the `ReceiveHistoricalWeatherForecastRequest` named `forecast_horizon_min` and `forecast_horizon_max`. This field introduces the ability to limit the forecast horizon of the received forecasts for the historical RPC.