### PR TITLE
Bump setuptools to 69.5.1 and setuptools_scm to 8.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 
 [build-system]
 requires = [
-  "setuptools == 68.1.0",
-  "setuptools_scm[toml] == 7.1.0",
+  "setuptools == 69.5.1",
+  "setuptools_scm[toml] == 8.3.1",
   "frequenz-repo-config[api] == 0.10.0",
   # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
   # sure the code is generated using the minimum supported versions, as older


### PR DESCRIPTION
This is necessary to avoid deprecation warnings when uploading packages to PyPI:

> In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.
>
> In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. You do not need to remove the file.
